### PR TITLE
Release 1.0.0-alpha.1 (attempt 3) 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,6 +100,8 @@ publishing {
             it.artifact(javadocJar)
         }
         it.pom {
+            name.set("kotlinx.interval")
+            description.set("Kotlin multiplatform bounded open/closed generic intervals.")
             url.set("https://github.com/Whathecode/kotlinx.interval")
             licenses {
                 license {


### PR DESCRIPTION
There was still missing POM information causing the release to fail on Maven.