### PR TITLE
Add `IntervalUnion` and `MutableIntervalUnion`

### DIFF
--- a/kotlinx.interval.test/src/commonMain/kotlin/IntervalTest.kt
+++ b/kotlinx.interval.test/src/commonMain/kotlin/IntervalTest.kt
@@ -189,14 +189,26 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
         assertIntersects( abWithoutB, bcWithB, false )
     }
 
+    @Test
+    fun reverse_succeeds()
+    {
+        val toReverse = createAllInclusionTypeIntervals( a, b )
+        for ( original in toReverse )
+        {
+            val reversed = original.reverse()
+            assertEquals( original.start, reversed.end )
+            assertEquals( original.isStartIncluded, reversed.isEndIncluded )
+            assertEquals( original.end, reversed.start )
+            assertEquals( original.isEndIncluded, reversed.isStartIncluded )
+        }
+    }
+
     private fun assertIntersects( interval1: Interval<T, TSize>, interval2: Interval<T, TSize>, intersects: Boolean )
     {
         assertEquals( intersects, interval1.intersects( interval2 ) )
         assertEquals( intersects, interval2.intersects( interval1 ) )
 
         // Reversing intervals should have no effect on whether they intersect or not.
-        fun Interval<T, TSize>.reverse() =
-            Interval( this.end, this.isEndIncluded, this.start, this.isStartIncluded, operations )
         val interval1Reversed = interval1.reverse()
         val interval2Reversed = interval2.reverse()
 

--- a/kotlinx.interval.test/src/commonMain/kotlin/IntervalTest.kt
+++ b/kotlinx.interval.test/src/commonMain/kotlin/IntervalTest.kt
@@ -190,6 +190,28 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
     }
 
     @Test
+    fun nonReversed_reversed_when_isReversed()
+    {
+        val reversed = createAllInclusionTypeIntervals( b, a )
+        for ( original in reversed )
+        {
+            val normal = original.nonReversed()
+            assertEquals( original.reverse(), normal )
+        }
+    }
+
+    @Test
+    fun nonReversed_unchanged_when_not_isReversed()
+    {
+        val normal = createAllInclusionTypeIntervals( a, b )
+        for ( original in normal )
+        {
+            val unchanged = original.nonReversed()
+            assertEquals( original, unchanged )
+        }
+    }
+
+    @Test
     fun reverse_succeeds()
     {
         val toReverse = createAllInclusionTypeIntervals( a, b )

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -91,9 +91,8 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
      */
     fun intersects( interval: Interval<T, TSize> ): Boolean
     {
-        fun Interval<T, TSize>.normalize() = if ( isReversed ) reverse() else this
-        val interval1 = this.normalize()
-        val interval2 = interval.normalize()
+        val interval1 = nonReversed()
+        val interval2 = interval.nonReversed()
 
         val rightOfCompare: Int = interval2.start.compareTo( interval1.end )
         val leftOfCompare: Int = interval2.end.compareTo( interval1.start )
@@ -103,6 +102,13 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
             leftOfCompare < 0 || ( leftOfCompare == 0 && !(interval2.isEndIncluded && interval1.isStartIncluded) )
         return !( liesRightOf || liesLeftOf )
     }
+
+    /**
+     * [reverse] the interval in case [start] is greater than [end] (the interval [isReversed]),
+     * or return the interval unchanged otherwise.
+     * Either way, the returned interval represents the same set of all [T] values.
+     */
+    fun nonReversed(): Interval<T, TSize> = if ( isReversed ) reverse() else this
 
     /**
      * Return an interval representing the same set of all [T] values,

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -91,9 +91,7 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
      */
     fun intersects( interval: Interval<T, TSize> ): Boolean
     {
-        fun Interval<T, TSize>.normalize() =
-            if ( isReversed ) Interval( end, isEndIncluded, start, isStartIncluded, operations )
-            else this
+        fun Interval<T, TSize>.normalize() = if ( isReversed ) reverse() else this
         val interval1 = this.normalize()
         val interval2 = interval.normalize()
 
@@ -105,6 +103,13 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
             leftOfCompare < 0 || ( leftOfCompare == 0 && !(interval2.isEndIncluded && interval1.isStartIncluded) )
         return !( liesRightOf || liesLeftOf )
     }
+
+    /**
+     * Return an interval representing the same set of all [T] values,
+     * but swap [start] and [isStartIncluded] with [end] and [isEndIncluded].
+     */
+    fun reverse(): Interval<T, TSize> =
+        Interval( this.end, this.isEndIncluded, this.start, this.isStartIncluded, operations )
 
     /**
      * Determines whether this interval equals [other]'s constructor parameters exactly,

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -87,6 +87,26 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
     }
 
     /**
+     * Determines whether [interval] has at least one value in common with this interval.
+     */
+    fun intersects( interval: Interval<T, TSize> ): Boolean
+    {
+        fun Interval<T, TSize>.normalize() =
+            if ( isReversed ) Interval( end, isEndIncluded, start, isStartIncluded, operations )
+            else this
+        val interval1 = this.normalize()
+        val interval2 = interval.normalize()
+
+        val rightOfCompare: Int = interval2.start.compareTo( interval1.end )
+        val leftOfCompare: Int = interval2.end.compareTo( interval1.start )
+        val liesRightOf =
+            rightOfCompare > 0 || ( rightOfCompare == 0 && !(interval2.isStartIncluded && interval1.isEndIncluded) )
+        val liesLeftOf =
+            leftOfCompare < 0 || ( leftOfCompare == 0 && !(interval2.isEndIncluded && interval1.isStartIncluded) )
+        return !( liesRightOf || liesLeftOf )
+    }
+
+    /**
      * Determines whether this interval equals [other]'s constructor parameters exactly,
      * i.e., not whether they represent the same set of [T] values, such as matching inverse intervals.
      */

--- a/kotlinx.interval/src/commonMain/kotlin/IntervalUnion.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/IntervalUnion.kt
@@ -20,14 +20,13 @@ internal class MutableIntervalUnion<T : Comparable<T>, TSize : Comparable<TSize>
 
     fun add( interval: Interval<T, TSize> )
     {
-        require( !interval.isReversed ) { "The interval is reversed. Normalized form is required." }
+        require( !interval.isReversed )
+            { "The interval is reversed. Normalized form is required." }
         require( intervals.all { it.start < interval.start } )
             { "The interval lies before a previously added interval." }
         val last = intervals.lastOrNull()
-        require(
-            last == null ||
-            (interval.start > last.end || interval.start == last.end && interval.isStartIncluded != last.isEndIncluded)
-        ) { "The interval overlaps with a previously added interval." }
+        require( last == null || !interval.intersects( last ) )
+            { "The interval overlaps with a previously added interval." }
 
         intervals.add( interval )
     }

--- a/kotlinx.interval/src/commonMain/kotlin/IntervalUnion.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/IntervalUnion.kt
@@ -1,0 +1,34 @@
+package io.github.whathecode.kotlinx.interval
+
+
+/**
+ * Represents a set of all [T] values contained in a collection of non-overlapping [Interval]s,
+ * stored in normalized form and ordered by their start values.
+ */
+sealed interface IntervalUnion<T : Comparable<T>, TSize : Comparable<TSize>> : Iterable<Interval<T, TSize>>
+
+
+/**
+ * An [IntervalUnion] which new intervals can be added to,
+ * as long as they are in normalized form, lie after, and don't overlap with previously added intervals.
+ */
+internal class MutableIntervalUnion<T : Comparable<T>, TSize : Comparable<TSize>> : IntervalUnion<T, TSize>
+{
+    private val intervals: MutableList<Interval<T, TSize>> = mutableListOf()
+
+    override fun iterator(): Iterator<Interval<T, TSize>> = intervals.iterator()
+
+    fun add( interval: Interval<T, TSize> )
+    {
+        require( !interval.isReversed ) { "The interval is reversed. Normalized form is required." }
+        require( intervals.all { it.start < interval.start } )
+            { "The interval lies before a previously added interval." }
+        val last = intervals.lastOrNull()
+        require(
+            last == null ||
+            (interval.start > last.end || interval.start == last.end && interval.isStartIncluded != last.isEndIncluded)
+        ) { "The interval overlaps with a previously added interval." }
+
+        intervals.add( interval )
+    }
+}

--- a/kotlinx.interval/src/commonTest/kotlin/MutableIntervalUnionTest.kt
+++ b/kotlinx.interval/src/commonTest/kotlin/MutableIntervalUnionTest.kt
@@ -1,0 +1,78 @@
+package io.github.whathecode.kotlinx.interval
+
+import kotlin.test.*
+
+
+/**
+ * Tests for [IntervalUnion].
+ */
+class MutableIntervalUnionTest
+{
+    // There is no reason to believe interval unions of different types behave differently.
+    // Testing one type should suffice.
+    private fun createEmptyUnion() = MutableIntervalUnion<Int, UInt>()
+
+    @Test
+    fun add_to_empty_succeeds()
+    {
+        val union = createEmptyUnion()
+
+        val toAdd = interval( 0, 10 )
+        union.add( toAdd )
+
+        assertEquals( toAdd, union.single() )
+    }
+
+    @Test
+    fun add_to_previous_succeeds()
+    {
+        val union = createEmptyUnion()
+        union.add( interval( 0, 10 ) )
+
+        val liesAfter = interval( 20, 30 )
+        union.add( liesAfter )
+
+        assertEquals( liesAfter, union.last() )
+    }
+
+    @Test
+    fun add_non_normalized_fails()
+    {
+        val union = createEmptyUnion()
+
+        val nonNormalized = interval( 10, 0 )
+        assertFailsWith<IllegalArgumentException> { union.add( nonNormalized ) }
+    }
+
+    @Test
+    fun add_preceding_interval_fails()
+    {
+        val union = createEmptyUnion()
+        union.add( interval( 5, 10 ) )
+
+        val liesBefore = interval( 0, 4 )
+        assertFailsWith<IllegalArgumentException> { union.add( liesBefore ) }
+    }
+
+    @Test
+    fun add_overlapping_interval_fails()
+    {
+        val union = createEmptyUnion()
+        union.add( interval( 0, 10 ) )
+
+        val overlaps = interval( 5, 15 )
+        assertFailsWith<IllegalArgumentException> { union.add( overlaps ) }
+        val endPointOverlaps = interval( 10, 20 )
+        assertFailsWith<IllegalArgumentException> { union.add( endPointOverlaps ) }
+    }
+
+    @Test
+    fun add_non_overlapping_endpoint_succeeds()
+    {
+        val union = createEmptyUnion()
+        union.add( interval( 0, 10 ) )
+
+        val nonOverlappingEndPoint = interval( 10, 20, isStartIncluded = false )
+        union.add( nonOverlappingEndPoint )
+    }
+}


### PR DESCRIPTION
An initial contract definition for `IntervalUnion` and preliminary concrete `MutableIntervalUnion` which lives up to the contract by restricting which intervals can be added.

To help verify the `IntervalUnion` contract, I included the `Interval.intersects()`, `Interval.reverse()`, and `Interval.nonReversed()` methods.