### PR TITLE
Add tight upper/lower bounds accessors

### DIFF
--- a/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTest.kt
+++ b/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTest.kt
@@ -92,6 +92,32 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
     }
 
     @Test
+    fun lowerBound_and_upperBound()
+    {
+        val notReversed = createAllInclusionTypeIntervals( a, b )
+        notReversed.forEach {
+            assertEquals( a, it.lowerBound )
+            assertEquals( it.isStartIncluded, it.isLowerBoundIncluded )
+            assertEquals( b, it.upperBound )
+            assertEquals( it.isEndIncluded, it.isUpperBoundIncluded )
+        }
+
+        val reversed = createAllInclusionTypeIntervals( b, a )
+        reversed.forEach {
+            assertEquals( a, it.lowerBound )
+            assertEquals( it.isEndIncluded, it.isLowerBoundIncluded )
+            assertEquals( b, it.upperBound )
+            assertEquals( it.isStartIncluded, it.isUpperBoundIncluded )
+        }
+
+        val single = createClosedInterval( a, a )
+        assertEquals( a, single.lowerBound )
+        assertEquals( a, single.upperBound )
+        assertTrue( single.isLowerBoundIncluded )
+        assertTrue( single.isUpperBoundIncluded )
+    }
+
+    @Test
     fun size_for_normal_and_reverse_intervals_is_the_same()
     {
         val abIntervals = createAllInclusionTypeIntervals( a, b ) + createAllInclusionTypeIntervals( b, a )


### PR DESCRIPTION
This prevents having to call `nonReversed()` as was previously done in the operations, and thus heap allocations.

Closes #27 