### PR TITLE
Add extra `IntervalUnion` behavior

### DIFF
--- a/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTest.kt
+++ b/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTest.kt
@@ -207,7 +207,7 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
         val abIntervals = createAllInclusionTypeIntervals( a, b )
 
         for ( ab in abIntervals )
-            assertEquals( emptySet(), (ab - ab).toSet() )
+            assertTrue( (ab - ab).isEmpty() )
     }
 
     @Test
@@ -217,7 +217,7 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
         val adIntervals = createAllInclusionTypeIntervals( a, d )
 
         for ( bc in bcIntervals ) for ( ad in adIntervals )
-            assertEquals( emptySet(), (bc - ad).toSet() )
+            assertTrue( (bc - ad).isEmpty() )
     }
 
     @Test

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -5,6 +5,7 @@ package io.github.whathecode.kotlinx.interval
  * Represents a set of all [T] values lying between a provided [start] and [end] value.
  * [TSize] is the type used to represent the distance between [T] values.
  * The interval can be closed, open, or half-open, as determined by [isStartIncluded] and [isEndIncluded].
+ * But, it can never be empty. Empty sets are represented as [IntervalUnion], with no containing intervals, instead.
  *
  * @throws IllegalArgumentException if an open or half-open interval with the same start and end value is specified.
  */
@@ -17,7 +18,7 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
      * Provide access to the predefined set of operators of [T] and [TSize] and conversions between them.
      */
     private val operations: IntervalTypeOperations<T, TSize>,
-)
+) : IntervalUnion<T, TSize>
 {
     init
     {
@@ -113,11 +114,7 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
         val result = MutableIntervalUnion<T, TSize>()
 
         // When the interval to subtract lies in front or behind, the current interval is unaffected.
-        if ( leftOfCompare > 0 || rightOfCompare < 0 )
-        {
-            result.add( this )
-            return result
-        }
+        if ( leftOfCompare > 0 || rightOfCompare < 0 ) return this
 
         // If the interval to subtract starts after the start of this interval, add the remaining lower bound chunk.
         val startCompare: Int = lowerBound.compareTo( toSubtract.lowerBound )
@@ -196,4 +193,6 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
         result = 31 * result + isEndIncluded.hashCode()
         return result
     }
+
+    override fun iterator(): Iterator<Interval<T, TSize>> = listOf( this ).iterator()
 }

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -17,7 +17,7 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
     /**
      * Provide access to the predefined set of operators of [T] and [TSize] and conversions between them.
      */
-    private val operations: IntervalTypeOperations<T, TSize>,
+    internal val operations: IntervalTypeOperations<T, TSize>
 ) : IntervalUnion<T, TSize>
 {
     init
@@ -194,5 +194,7 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
         return result
     }
 
+    // IntervalUnion implementation; Interval is an IntervalUnion with a single interval.
     override fun iterator(): Iterator<Interval<T, TSize>> = listOf( this ).iterator()
+    override fun getBounds(): Interval<T, TSize> = this
 }

--- a/kotlinx.interval/src/commonMain/kotlin/IntervalUnion.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/IntervalUnion.kt
@@ -2,10 +2,16 @@ package io.github.whathecode.kotlinx.interval
 
 
 /**
- * Represents a set of all [T] values contained in a collection of non-overlapping [Interval]s,
- * stored in normalized form and ordered by their start values.
+ * Represents a set of all [T] values contained in a collection of non-overlapping [Interval]s.
+ * If the collection contains no intervals, it represents an empty set.
  */
 sealed interface IntervalUnion<T : Comparable<T>, TSize : Comparable<TSize>> : Iterable<Interval<T, TSize>>
+{
+    /**
+     * Determines whether this is an empty set, i.e., no value of [T] is contained within.
+     */
+    fun isEmpty(): Boolean = none()
+}
 
 
 /**

--- a/kotlinx.interval/src/commonMain/kotlin/IntervalUnion.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/IntervalUnion.kt
@@ -11,6 +11,12 @@ sealed interface IntervalUnion<T : Comparable<T>, TSize : Comparable<TSize>> : I
      * Determines whether this is an empty set, i.e., no value of [T] is contained within.
      */
     fun isEmpty(): Boolean = none()
+
+    /**
+     * Gets the upper and lower bound of this set, and whether they are included. Or, `null` if the set is empty.
+     * Unlike an interval, not all values lying within the upper and lower bound are necessarily part of this set.
+     */
+    fun getBounds(): Interval<T, TSize>?
 }
 
 
@@ -23,6 +29,15 @@ internal class MutableIntervalUnion<T : Comparable<T>, TSize : Comparable<TSize>
     private val intervals: MutableList<Interval<T, TSize>> = mutableListOf()
 
     override fun iterator(): Iterator<Interval<T, TSize>> = intervals.iterator()
+
+    override fun getBounds(): Interval<T, TSize>?
+    {
+        if (isEmpty()) return null
+
+        val first: Interval<T, TSize> = intervals.first()
+        val last: Interval<T, TSize> = intervals.last()
+        return Interval( first.start, first.isStartIncluded, last.end, last.isEndIncluded, first.operations )
+    }
 
     fun add( interval: Interval<T, TSize> )
     {

--- a/kotlinx.interval/src/commonTest/kotlin/MutableIntervalUnionTest.kt
+++ b/kotlinx.interval/src/commonTest/kotlin/MutableIntervalUnionTest.kt
@@ -13,6 +13,35 @@ class MutableIntervalUnionTest
     private fun createEmptyUnion() = MutableIntervalUnion<Int, UInt>()
 
     @Test
+    fun getBounds_for_empty_union_is_null()
+    {
+        val empty = createEmptyUnion()
+        assertEquals( null, empty.getBounds() )
+    }
+
+    @Test
+    fun getBounds_for_single_interval_equals_interval()
+    {
+        val union = createEmptyUnion()
+        val single = interval( 0, 10 )
+        union.add( single )
+
+        assertEquals( single, union.getBounds() )
+    }
+
+    @Test
+    fun getBounds_for_multiple_intervals()
+    {
+        val union = createEmptyUnion()
+        val first = interval( 0, 10 )
+        val lastHalfOpen = interval( 15,20, isEndIncluded = false )
+        union.add( first )
+        union.add( lastHalfOpen )
+
+        assertEquals( interval( 0, 20, isEndIncluded = false ), union.getBounds() )
+    }
+
+    @Test
     fun add_to_empty_succeeds()
     {
         val union = createEmptyUnion()


### PR DESCRIPTION
Treat `Interval` as a `IntervalUnion` with a single interval, and added `isEmpty()` and `getBounds()` to `IntervalUnion`.

In addition, I removed normalized form and order requirements from the `IntervalUnion` interface documentation/contract. I see no reason yet why that should be enforced, and it can remain an implementation detail of the concrete mutable class.

Part of #28, but without any optimization
Closes #31 