### PR TITLE
Add `Interval.canonicalize` and `.setEquals`

### DIFF
--- a/kotlinx.interval.datetime/src/commonMain/kotlin/DateTimeTypeOperations.kt
+++ b/kotlinx.interval.datetime/src/commonMain/kotlin/DateTimeTypeOperations.kt
@@ -11,6 +11,7 @@ internal object InstantOperations : TypeOperations<Instant>
     override val additiveIdentity: Instant = Instant.fromEpochMilliseconds( 0 )
     override val minValue: Instant = Instant.fromEpochSeconds( Long.MIN_VALUE, Long.MIN_VALUE )
     override val maxValue: Instant = Instant.fromEpochSeconds( Long.MAX_VALUE, Long.MAX_VALUE )
+    override val spacing: Instant? = null
 
     override fun unsafeAdd( a: Instant, b: Instant ): Instant = Instant.fromEpochSeconds(
         a.epochSeconds + b.epochSeconds,
@@ -31,6 +32,7 @@ internal object DurationOperations : TypeOperations<Duration>
     private const val MAX_MILLIS = Long.MAX_VALUE / 2
     override val minValue: Duration = -MAX_MILLIS.milliseconds
     override val maxValue: Duration = MAX_MILLIS.milliseconds
+    override val spacing: Duration? = null
 
     override fun unsafeAdd( a: Duration, b: Duration ): Duration = a + b
     override fun unsafeSubtract( a: Duration, b: Duration ): Duration = a - b

--- a/kotlinx.interval/src/commonMain/kotlin/BasicTypeOperations.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/BasicTypeOperations.kt
@@ -138,8 +138,7 @@ internal object ULongOperations : TypeOperations<ULong>
 
 internal object CharOperations : TypeOperations<Char>
 {
-    // HACK: a getter is added to fields to work around a JS legacy boxing/unboxing bug.
-    override val additiveIdentity: Char get() = Char( 0 )
+    override val additiveIdentity: Char = Char( 0 )
     override val minValue: Char get() = Char.MIN_VALUE
     override val maxValue: Char get() = Char.MAX_VALUE
 

--- a/kotlinx.interval/src/commonMain/kotlin/BasicTypeOperations.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/BasicTypeOperations.kt
@@ -41,6 +41,7 @@ internal object ByteOperations : TypeOperations<Byte>
     override val additiveIdentity: Byte = 0
     override val minValue: Byte = Byte.MIN_VALUE
     override val maxValue: Byte = Byte.MAX_VALUE
+    override val spacing: Byte = 1
 
     override fun unsafeAdd( a: Byte, b: Byte ): Byte = (a + b).toByte()
     override fun unsafeSubtract( a: Byte, b: Byte ): Byte = (a - b).toByte()
@@ -51,6 +52,7 @@ internal object ShortOperations : TypeOperations<Short>
     override val additiveIdentity: Short = 0
     override val minValue: Short = Short.MIN_VALUE
     override val maxValue: Short = Short.MAX_VALUE
+    override val spacing: Short = 1
 
     override fun unsafeAdd( a: Short, b: Short ): Short = (a + b).toShort()
     override fun unsafeSubtract( a: Short, b: Short ): Short = (a - b).toShort()
@@ -61,6 +63,7 @@ internal object IntOperations : TypeOperations<Int>
     override val additiveIdentity: Int = 0
     override val minValue: Int = Int.MIN_VALUE
     override val maxValue: Int = Int.MAX_VALUE
+    override val spacing: Int = 1
 
     override fun unsafeAdd( a: Int, b: Int ): Int = a + b
     override fun unsafeSubtract( a: Int, b: Int ): Int = a - b
@@ -71,6 +74,7 @@ internal object LongOperations : TypeOperations<Long>
     override val additiveIdentity: Long = 0
     override val minValue: Long = Long.MIN_VALUE
     override val maxValue: Long = Long.MAX_VALUE
+    override val spacing: Long = 1
 
     override fun unsafeAdd( a: Long, b: Long ): Long = a + b
     override fun unsafeSubtract( a: Long, b: Long ): Long = a - b
@@ -81,6 +85,7 @@ internal object FloatOperations : TypeOperations<Float>
     override val additiveIdentity: Float = 0f
     override val minValue: Float = -Float.MAX_VALUE
     override val maxValue: Float = Float.MAX_VALUE
+    override val spacing: Float? = null
 
     override fun unsafeAdd( a: Float, b: Float ): Float = a + b
     override fun unsafeSubtract( a: Float, b: Float ): Float = a - b
@@ -91,6 +96,7 @@ internal object DoubleOperations : TypeOperations<Double>
     override val additiveIdentity: Double = 0.0
     override val minValue: Double = -Double.MAX_VALUE
     override val maxValue: Double = Double.MAX_VALUE
+    override val spacing: Double? = null
 
     override fun unsafeAdd( a: Double, b: Double ): Double = a + b
     override fun unsafeSubtract( a: Double, b: Double ): Double = a - b
@@ -101,6 +107,7 @@ internal object UByteOperations : TypeOperations<UByte>
     override val additiveIdentity: UByte = 0.toUByte()
     override val minValue: UByte = UByte.MIN_VALUE
     override val maxValue: UByte = UByte.MAX_VALUE
+    override val spacing: UByte = 1.toUByte()
 
     override fun unsafeAdd( a: UByte, b: UByte ): UByte = (a + b).toUByte()
     override fun unsafeSubtract( a: UByte, b: UByte ): UByte = (a - b).toUByte()
@@ -111,6 +118,7 @@ internal object UShortOperations : TypeOperations<UShort>
     override val additiveIdentity: UShort = 0.toUShort()
     override val minValue: UShort = UShort.MIN_VALUE
     override val maxValue: UShort = UShort.MAX_VALUE
+    override val spacing: UShort? = 1.toUShort()
 
     override fun unsafeAdd( a: UShort, b: UShort ): UShort = (a + b).toUShort()
     override fun unsafeSubtract( a: UShort, b: UShort ): UShort = (a - b).toUShort()
@@ -121,6 +129,7 @@ internal object UIntOperations : TypeOperations<UInt>
     override val additiveIdentity: UInt = 0.toUInt()
     override val minValue: UInt = UInt.MIN_VALUE
     override val maxValue: UInt = UInt.MAX_VALUE
+    override val spacing: UInt? = 1.toUInt()
 
     override fun unsafeAdd( a: UInt, b: UInt ): UInt = a + b
     override fun unsafeSubtract( a: UInt, b: UInt ): UInt = a - b
@@ -131,6 +140,7 @@ internal object ULongOperations : TypeOperations<ULong>
     override val additiveIdentity: ULong = 0.toULong()
     override val minValue: ULong = ULong.MIN_VALUE
     override val maxValue: ULong = ULong.MAX_VALUE
+    override val spacing: ULong? = 1.toULong()
 
     override fun unsafeAdd( a: ULong, b: ULong ): ULong = a + b
     override fun unsafeSubtract( a: ULong, b: ULong ): ULong = a - b
@@ -141,6 +151,7 @@ internal object CharOperations : TypeOperations<Char>
     override val additiveIdentity: Char = Char( 0 )
     override val minValue: Char get() = Char.MIN_VALUE
     override val maxValue: Char get() = Char.MAX_VALUE
+    override val spacing: Char? = Char( 1 )
 
     override fun unsafeAdd( a: Char, b: Char ): Char = a + b.code
     override fun unsafeSubtract( a: Char, b: Char ): Char = (a - b).toChar()

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -205,6 +205,22 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
         Interval( this.end, this.isEndIncluded, this.start, this.isStartIncluded, operations )
 
     /**
+     * Returns the canonical form of the set of all [T] values represented by this interval.
+     * The canonical form is [nonReversed], and for evenly-spaced types (e.g., integers) turns exclusive bounds
+     * into inclusive bounds. E.g. The canonical form of [5, 1) is [2, 5].
+     */
+    fun canonicalize(): Interval<T, TSize>
+    {
+        // Only evenly-spaced types with exclusive bounds can do more than reversing the interval if needed.
+        val spacing = valueOperations.spacing
+        if ( spacing == null || (isStartIncluded && isEndIncluded) ) return nonReversed()
+
+        val start = if ( isLowerBoundIncluded ) lowerBound else valueOperations.unsafeAdd( lowerBound, spacing )
+        val end = if ( isUpperBoundIncluded ) upperBound else valueOperations.unsafeSubtract( upperBound, spacing )
+        return Interval( start, true, end, true, operations )
+    }
+
+    /**
      * Determines whether this interval equals [other]'s constructor parameters exactly,
      * i.e., not whether they represent the same set of [T] values, such as matching inverse intervals.
      */

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -221,6 +221,14 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
     }
 
     /**
+     * Determines whether this interval represents the same set of values as the [other] interval.
+     *
+     * Intervals with differing constructor parameters may still represent the same values,
+     * e.g., when they are reversed. For exact equality, use [equals].
+     */
+    fun setEquals( other: Interval<T, TSize> ): Boolean = this.canonicalize() == other.canonicalize()
+
+    /**
      * Determines whether this interval equals [other]'s constructor parameters exactly,
      * i.e., not whether they represent the same set of [T] values, such as matching inverse intervals.
      */

--- a/kotlinx.interval/src/commonMain/kotlin/TypeOperations.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/TypeOperations.kt
@@ -22,6 +22,12 @@ interface TypeOperations<T : Comparable<T>>
     val maxValue: T
 
     /**
+     * If values of [T] are evenly spaced, the distance between each subsequent value of [T];
+     * null otherwise, e.g., if values of [T] are dense.
+     */
+    val spacing: T?
+
+    /**
      * The binary operation `a + b`, not safeguarded against overflows.
      * The resulting type is cast back to type [T].
      */

--- a/kotlinx.interval/src/commonTest/kotlin/BasicTypeIntervalsTest.kt
+++ b/kotlinx.interval/src/commonTest/kotlin/BasicTypeIntervalsTest.kt
@@ -17,4 +17,4 @@ object UIntIntervalTest :
     IntervalTest<UInt, UInt>( 0.toUInt(), 5.toUInt(), 10.toUInt(), 5.toUInt(), UIntInterval.Operations )
 object ULongIntervalTest :
     IntervalTest<ULong, ULong>( 0.toULong(), 5.toULong(), 10.toULong(), 5.toULong(), ULongInterval.Operations )
-object CharIntervalTest : IntervalTest<Char, UShort>( 'a', 'b', 'c', 1.toUShort(), CharInterval.Operations )
+object CharIntervalTest : IntervalTest<Char, UShort>( 'a', 'c', 'e', 2.toUShort(), CharInterval.Operations )


### PR DESCRIPTION
Implementing `Interval.setEquals` is part of #36, but it doesn't implement this yet for `IntervalUnion`.

To implement this easily, a `canonicalize` method was implemented: closes #20