### PR TITLE
Add `IntervalUnion.setEquals()`

### DIFF
--- a/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTest.kt
+++ b/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTest.kt
@@ -2,6 +2,7 @@ package io.github.whathecode.kotlinx.interval.test
 
 import io.github.whathecode.kotlinx.interval.Interval
 import io.github.whathecode.kotlinx.interval.IntervalTypeOperations
+import io.github.whathecode.kotlinx.interval.IntervalUnion
 import kotlin.test.*
 
 
@@ -193,7 +194,7 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
                 createInterval( a, ad.isStartIncluded, b, !bc.isStartIncluded ),
                 createInterval( c, !bc.isEndIncluded, d, ad.isEndIncluded )
             )
-            assertEquals( expected, (ad - bc).toSet() )
+            assertUnionEquals( expected, ad - bc )
         }
     }
 
@@ -205,9 +206,9 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
 
         for ( ac in acIntervals ) for ( bd in bdIntervals )
         {
-            assertEquals(
+            assertUnionEquals(
                 createInterval( a, ac.isStartIncluded, b, !bd.isStartIncluded ),
-                (ac - bd).singleOrNull()
+                ac - bd
             )
         }
     }
@@ -271,9 +272,9 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
     {
         val abWithB = createClosedInterval( a, b )
         val bcWithB = createClosedInterval( b, c )
-        assertEquals(
+        assertUnionEquals(
             createInterval( a, true, b, false ),
-            (abWithB - bcWithB).singleOrNull()
+            (abWithB - bcWithB)
         )
 
         val bcWithoutB = createOpenInterval( b, c )
@@ -331,7 +332,7 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
         val cdIntervals = createAllInclusionTypeIntervals( c, d )
 
         for ( ab in abIntervals ) for ( cd in cdIntervals )
-            assertEquals( setOf( ab, cd ), (ab + cd).toSet() )
+            assertUnionEquals( setOf( ab, cd ), ab + cd )
     }
 
     @Test
@@ -576,5 +577,16 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
 
         assertEquals( intersects, interval1Reversed.intersects( interval2Reversed ) )
         assertEquals( intersects, interval2Reversed.intersects( interval1Reversed ) )
+    }
+
+    private fun assertUnionEquals( expected: Interval<T, TSize>, actual: IntervalUnion<T, TSize> ) =
+        assertUnionEquals( setOf( expected ), actual )
+
+    private fun assertUnionEquals( expected: Set<Interval<T, TSize>>, actual: IntervalUnion<T, TSize> )
+    {
+        // Compare canonical form of intervals since unions only contain canonical intervals.
+        val expectedSet = expected.map { it.canonicalize() }.toSet()
+
+        assertEquals( expectedSet, actual.toSet() )
     }
 }

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -28,7 +28,7 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
         }
     }
 
-    private val valueOperations = operations.valueOperations
+    internal val valueOperations = operations.valueOperations
     private val sizeOperations = operations.sizeOperations
 
 

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -228,6 +228,12 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
      */
     fun setEquals( other: Interval<T, TSize> ): Boolean = this.canonicalize() == other.canonicalize()
 
+    override fun setEquals( other: IntervalUnion<T, TSize> ): Boolean
+    {
+        val otherInterval = other.singleOrNull() ?: return false
+        return setEquals( otherInterval )
+    }
+
     /**
      * Determines whether this interval equals [other]'s constructor parameters exactly,
      * i.e., not whether they represent the same set of [T] values, such as matching inverse intervals.

--- a/kotlinx.interval/src/commonMain/kotlin/IntervalUnion.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/IntervalUnion.kt
@@ -18,6 +18,11 @@ sealed interface IntervalUnion<T : Comparable<T>, TSize : Comparable<TSize>> : I
      * Unlike an interval, not all values lying within the upper and lower bound are necessarily part of this set.
      */
     fun getBounds(): Interval<T, TSize>?
+
+    /**
+     * Determines whether this [IntervalUnion] represents the same set of values as the [other] union.
+     */
+    fun setEquals( other: IntervalUnion<T, TSize> ): Boolean
 }
 
 
@@ -58,6 +63,8 @@ internal class MutableIntervalUnion<T : Comparable<T>, TSize : Comparable<TSize>
         return liesAfter &&
             (spacing == null || interval.valueOperations.unsafeSubtract( this.start, interval.end ) > spacing)
     }
+
+    override fun setEquals( other: IntervalUnion<T, TSize> ): Boolean = this.toSet() == other.toSet()
 
     override fun toString(): String = joinToString( prefix = "[", postfix = "]" )
 }

--- a/kotlinx.interval/src/commonTest/kotlin/MutableIntervalUnionTest.kt
+++ b/kotlinx.interval/src/commonTest/kotlin/MutableIntervalUnionTest.kt
@@ -117,6 +117,42 @@ class MutableIntervalUnionTest
     }
 
     @Test
+    fun setEquals_with_evenly_spaced_types_succeeds()
+    {
+        val union = createEmptyUnion()
+        union.add( interval( 0, 5 ) )
+        union.add( interval( 10, 15, isEndIncluded = false ) )
+
+        val sameUnion = createEmptyUnion()
+        sameUnion.add( interval( 0, 5 ) )
+        sameUnion.add( interval( 10, 14 ) )
+        assertTrue( union.setEquals( sameUnion ) )
+
+        val differentUnion = createEmptyUnion()
+        differentUnion.add( interval( 0, 5 ) )
+        differentUnion.add( interval( 10, 15 ) )
+        assertFalse( union.setEquals( differentUnion ) )
+    }
+
+    @Test
+    fun setEquals_with_non_evenly_spaced_types_succeeds()
+    {
+        val union = MutableIntervalUnion<Float, Double>()
+        union.add( interval( 0f, 5f ) )
+        union.add( interval( 10f, 15f, isEndIncluded = false ) )
+
+        val sameUnion = MutableIntervalUnion<Float, Double>()
+        sameUnion.add( interval( 0f, 5f ) )
+        sameUnion.add( interval( 10f, 15f, isEndIncluded = false ) )
+        assertTrue( union.setEquals( sameUnion ) )
+
+        val differentUnion = MutableIntervalUnion<Float, Double>()
+        differentUnion.add( interval( 0f, 5f ) )
+        differentUnion.add( interval( 10f, 15f ) )
+        assertFalse( union.setEquals( differentUnion ) )
+    }
+
+    @Test
     fun toString_matches_default_list_formatting()
     {
         val union = createEmptyUnion()

--- a/kotlinx.interval/src/commonTest/kotlin/MutableIntervalUnionTest.kt
+++ b/kotlinx.interval/src/commonTest/kotlin/MutableIntervalUnionTest.kt
@@ -8,8 +8,8 @@ import kotlin.test.*
  */
 class MutableIntervalUnionTest
 {
-    // There is no reason to believe interval unions of different types behave differently.
-    // Testing one type should suffice.
+    // For the majority of tests, testing using an evenly-spaced type suffices.
+    // Tests which rely on a non-evenly-spaced type shouldn't use this.
     private fun createEmptyUnion() = MutableIntervalUnion<Int, UInt>()
 
     @Test
@@ -30,15 +30,25 @@ class MutableIntervalUnionTest
     }
 
     @Test
+    fun getBounds_for_non_canonical_interval_is_canonicalized()
+    {
+        val union = createEmptyUnion()
+        val nonCanonical = interval( 10, 0, isStartIncluded = false )
+        union.add( nonCanonical )
+
+        assertEquals( interval( 0, 9 ), union.getBounds() )
+    }
+
+    @Test
     fun getBounds_for_multiple_intervals()
     {
         val union = createEmptyUnion()
         val first = interval( 0, 10 )
-        val lastHalfOpen = interval( 15,20, isEndIncluded = false )
+        val last = interval( 15, 20 )
         union.add( first )
-        union.add( lastHalfOpen )
+        union.add( last )
 
-        assertEquals( interval( 0, 20, isEndIncluded = false ), union.getBounds() )
+        assertEquals( interval( 0, 20 ), union.getBounds() )
     }
 
     @Test
@@ -65,15 +75,6 @@ class MutableIntervalUnionTest
     }
 
     @Test
-    fun add_non_normalized_fails()
-    {
-        val union = createEmptyUnion()
-
-        val nonNormalized = interval( 10, 0 )
-        assertFailsWith<IllegalArgumentException> { union.add( nonNormalized ) }
-    }
-
-    @Test
     fun add_preceding_interval_fails()
     {
         val union = createEmptyUnion()
@@ -96,12 +97,22 @@ class MutableIntervalUnionTest
     }
 
     @Test
-    fun add_non_overlapping_endpoint_succeeds()
+    fun add_adjacent_interval_fails()
     {
         val union = createEmptyUnion()
         union.add( interval( 0, 10 ) )
 
-        val nonOverlappingEndPoint = interval( 10, 20, isStartIncluded = false )
+        val adjacent = interval( 11, 20 )
+        assertFailsWith<IllegalArgumentException> { union.add( adjacent ) }
+    }
+
+    @Test
+    fun add_non_overlapping_endpoint_succeeds()
+    {
+        val union = MutableIntervalUnion<Float, Double>()
+        union.add( interval( 0f, 10f ) )
+
+        val nonOverlappingEndPoint = interval( 10f, 20f, isStartIncluded = false )
         union.add( nonOverlappingEndPoint )
     }
 


### PR DESCRIPTION
To easily compare whether two `IntervalUnion`'s equal, intervals within are now stored in canonical form. And, to make `IntervalUnion` as a whole canonical, a new contract is added that intervals are never adjacent, i.e., there always lie _some_ values in between two subsequent intervals of `IntervalUnion`. E.g. `[[0, 5], [6, 10]]` is invalid. 

Closes #36 