### PR TITLE
Fix: incorrect bound check in `Interval.minus`

### DIFF
--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -134,7 +134,7 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
 
         // If the interval to subtract ends before the end of this interval, add the remaining upper bound chunk.
         val upperCompare: Int = upperBound.compareTo( toSubtract.upperBound )
-        if ( upperCompare > 0 || ( upperCompare == 0 && isUpperBoundIncluded && !toSubtract.isEndIncluded ) )
+        if ( upperCompare > 0 || ( upperCompare == 0 && isUpperBoundIncluded && !toSubtract.isUpperBoundIncluded ) )
         {
             val upperBoundRemnant = Interval(
                 toSubtract.upperBound, !toSubtract.isUpperBoundIncluded,


### PR DESCRIPTION
I shortly looked at how to include coverage for this in the current test suite, but it feels extremely excessive to start adding reversed intervals in all checks, as tests then would have to start relying on `lowerBound` and `upperBound` checks instead of `start` and `end`, making them less self-contained. And, just adding a single test for this one bug wouldn't rule out all other places where `end` could be used incorrectly instead of `upperBound`.

Likely a better test strategy is needed here.

