### PR TITLE
Release 1.0.1 (with fixed history)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ if (publishPropertiesFile.exists()) {
     publishProperties.load(java.io.FileInputStream(publishPropertiesFile))
 }
 group = "io.github.whathecode.kotlinx.interval"
-version = "1.0.0"
+version = "1.0.1"
 nexusPublishing {
     repositories {
         sonatype {

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -134,7 +134,7 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
 
         // If the interval to subtract ends before the end of this interval, add the remaining upper bound chunk.
         val upperCompare: Int = upperBound.compareTo( toSubtract.upperBound )
-        if ( upperCompare > 0 || ( upperCompare == 0 && isUpperBoundIncluded && !toSubtract.isEndIncluded ) )
+        if ( upperCompare > 0 || ( upperCompare == 0 && isUpperBoundIncluded && !toSubtract.isUpperBoundIncluded ) )
         {
             val upperBoundRemnant = Interval(
                 toSubtract.upperBound, !toSubtract.isUpperBoundIncluded,


### PR DESCRIPTION
Bugfix: subtracting a reversed intervals which lies at the end of an interval with shared endpoints, but differing endpoint inclusion, would be incorrect.