### PR TITLE
Add a `IntervalUnion.shift` operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ The following operations are available for any `IntervalUnion<T, TSize>`:
 |    `getBounds()`    |                          Gets the upper and lower bound of the set.                          |
 | `contains()` (`in`) |                         Determines whether a value lies in the set.                          |
 |   `minus()` (`-`)   |                              Subtract an interval from the set.                              |
-|   `plus()` (`+`)    |                                Add an interval from the set.                                 |
+|   `plus()` (`+`)    |                                 Add an interval to the set.                                  |
+|      `shift()`      |                           Move the interval by a specified offset.                           |
 |   `intersects()`    |                Determines whether another interval intersects with this set.                 |
 |    `setEquals()`    |                     Determines whether a set represents the same values.                     |
 |    `iterator()`     |                      Iterate over all intervals in the union, in order.                      |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ if (publishPropertiesFile.exists()) {
     publishProperties.load(java.io.FileInputStream(publishPropertiesFile))
 }
 group = "io.github.whathecode.kotlinx.interval"
-version = "1.0.1"
+version = "2.0.0"
 nexusPublishing {
     repositories {
         sonatype {

--- a/kotlinx.interval.datetime/src/commonMain/kotlin/InstantInterval.kt
+++ b/kotlinx.interval.datetime/src/commonMain/kotlin/InstantInterval.kt
@@ -19,7 +19,7 @@ class InstantInterval( start: Instant, isStartIncluded: Boolean, end: Instant, i
         internal val Operations = object : IntervalTypeOperations<Instant, Duration>(
             InstantOperations,
             DurationOperations,
-            getDistanceTo = { (InstantOperations.additiveIdentity - it).absoluteValue },
+            getDistance = { a, b -> (b - a).absoluteValue },
             unsafeValueAt = { InstantOperations.additiveIdentity + it.absoluteValue }
         )
         {

--- a/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTest.kt
+++ b/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTest.kt
@@ -147,20 +147,6 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
     }
 
     @Test
-    fun size_can_be_greater_than_max_value()
-    {
-        val fullRange = createClosedInterval( operations.minValue, operations.maxValue ).size
-        val identity = valueOperations.additiveIdentity
-        val rangeBelowIdentity = createClosedInterval( operations.minValue, identity ).size
-        val rangeAboveIdentity = createClosedInterval( identity, operations.maxValue ).size
-
-        assertEquals(
-            fullRange,
-            sizeOperations.unsafeAdd( rangeBelowIdentity, rangeAboveIdentity )
-        )
-    }
-
-    @Test
     fun getBounds_returns_canonicalized_interval()
     {
         createAllInclusionTypeIntervals( a, b )

--- a/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTypeOperationsTest.kt
+++ b/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTypeOperationsTest.kt
@@ -14,16 +14,19 @@ open class IntervalTypeOperationsTest<T : Comparable<T>, TSize : Comparable<TSiz
 )
 {
     private val valueOperations = operations.valueOperations
+    private val valueZero = valueOperations.additiveIdentity
+
     private val sizeOperations = operations.sizeOperations
+    private val sizeZero = sizeOperations.additiveIdentity
 
 
     @Test
     fun minValue_can_be_converted_back_and_forth_using_TSize()
     {
         val min: T = operations.minValue
-        val minSize: TSize = operations.getDistance( valueOperations.additiveIdentity, min )
+        val minSize: TSize = operations.getDistance( valueZero, min )
         val minSizeValue: T = operations.unsafeValueAt( minSize )
-        val subtractedMinSize: T = valueOperations.unsafeSubtract( valueOperations.additiveIdentity, minSizeValue )
+        val subtractedMinSize: T = valueOperations.unsafeSubtract( valueZero, minSizeValue )
         assertEquals( min, subtractedMinSize )
     }
 
@@ -31,7 +34,7 @@ open class IntervalTypeOperationsTest<T : Comparable<T>, TSize : Comparable<TSiz
     fun maxValue_can_be_converted_back_and_forth_using_TSize()
     {
         val max: T = operations.maxValue
-        val maxSize: TSize = operations.getDistance( valueOperations.additiveIdentity, max )
+        val maxSize: TSize = operations.getDistance( valueZero, max )
         val maxSizeValue: T = operations.unsafeValueAt( maxSize )
         assertEquals( max, maxSizeValue )
     }
@@ -54,8 +57,8 @@ open class IntervalTypeOperationsTest<T : Comparable<T>, TSize : Comparable<TSiz
     {
         val value = operations.unsafeValueAt( positiveSize )
 
-        val distance1 = operations.getDistance( valueOperations.additiveIdentity, value )
-        val distance2 = operations.getDistance( value, valueOperations.additiveIdentity )
+        val distance1 = operations.getDistance( valueZero, value )
+        val distance2 = operations.getDistance( value, valueZero )
 
         assertEquals( positiveSize, distance1 )
         assertEquals( positiveSize, distance2 )
@@ -66,11 +69,11 @@ open class IntervalTypeOperationsTest<T : Comparable<T>, TSize : Comparable<TSiz
     {
         if ( !sizeOperations.isSignedType ) return
 
-        val negativeSize = sizeOperations.unsafeSubtract( sizeOperations.additiveIdentity, positiveSize )
+        val negativeSize = sizeOperations.unsafeSubtract( sizeZero, positiveSize )
         val valueAtNegative = operations.unsafeValueAt( negativeSize )
 
-        val distance1 = operations.getDistance( valueOperations.additiveIdentity, valueAtNegative )
-        val distance2 = operations.getDistance( valueAtNegative, valueOperations.additiveIdentity )
+        val distance1 = operations.getDistance( valueZero, valueAtNegative )
+        val distance2 = operations.getDistance( valueAtNegative, valueZero )
 
         assertEquals( positiveSize, distance1 )
         assertEquals( positiveSize, distance2 )
@@ -79,16 +82,100 @@ open class IntervalTypeOperationsTest<T : Comparable<T>, TSize : Comparable<TSiz
     @Test
     fun unsafeValueAt_is_always_positive()
     {
-        val zero = valueOperations.additiveIdentity
-
         val valueAtPositive = operations.unsafeValueAt( positiveSize )
-        assertTrue( valueAtPositive > zero, "$valueAtPositive isn't > $zero." )
+        assertTrue( valueAtPositive > valueZero, "$valueAtPositive isn't > $valueZero." )
 
         if ( sizeOperations.isSignedType )
         {
-            val negativeSize = sizeOperations.unsafeSubtract( sizeOperations.additiveIdentity, positiveSize )
+            val negativeSize = sizeOperations.unsafeSubtract( sizeZero, positiveSize )
             val valueAtNegative = operations.unsafeValueAt( negativeSize )
-            assertTrue( valueAtNegative > zero, "$valueAtNegative isn't > $zero." )
+            assertTrue( valueAtNegative > valueZero, "$valueAtNegative isn't > $valueZero." )
+        }
+    }
+
+    @Test
+    fun unsafeShift_with_positive_value()
+    {
+        val shiftedRight = operations.unsafeShift( valueZero, positiveSize, invertDirection = false )
+
+        val positiveValue = operations.unsafeValueAt( positiveSize )
+        assertEquals( positiveValue, shiftedRight )
+
+        val shiftedLeft = operations.unsafeShift( positiveValue, positiveSize, invertDirection = true )
+        assertEquals( valueZero, shiftedLeft )
+    }
+
+    @Test
+    fun unsafeShift_with_negative_value()
+    {
+        if ( !sizeOperations.isSignedType ) return
+
+        val negativeSize = sizeOperations.unsafeSubtract( sizeZero, positiveSize )
+        assertEquals(
+            operations.unsafeShift( valueZero, positiveSize, invertDirection = true ),
+            operations.unsafeShift( valueZero, negativeSize, invertDirection = false )
+        )
+        assertEquals(
+            operations.unsafeShift( valueZero, positiveSize, invertDirection = false ),
+            operations.unsafeShift( valueZero, negativeSize, invertDirection = true )
+        )
+    }
+
+    @Test
+    fun unsafeShift_zero()
+    {
+        val shiftedRight = operations.unsafeShift( valueZero, sizeZero, invertDirection = false )
+        assertEquals( valueZero, shiftedRight )
+
+        val shiftedLeft = operations.unsafeShift( valueZero, sizeZero, invertDirection = true )
+        assertEquals( valueZero, shiftedLeft )
+    }
+
+    @Test
+    fun unsafeShift_full_range()
+    {
+        val fullRange = operations.getDistance( operations.minValue, operations.maxValue )
+
+        val toMax = operations.unsafeShift( operations.minValue, fullRange, invertDirection = false )
+        assertEquals( operations.maxValue, toMax )
+
+        val toMin = operations.unsafeShift( operations.maxValue, fullRange, invertDirection = true )
+        assertEquals( operations.minValue, toMin )
+    }
+
+    @Test
+    fun unsafeShift_can_overflow()
+    {
+        val max = valueOperations.maxValue
+        val shiftMaxOverflow = operations.unsafeShift( valueOperations.maxValue, positiveSize, invertDirection = false )
+
+        val min = valueOperations.minValue
+        val shiftMinOverflow = operations.unsafeShift( valueOperations.minValue, positiveSize, invertDirection = true )
+
+        // Types either overflow, or are coerced to max value (e.g. floating points).
+        assertTrue( shiftMaxOverflow < max || shiftMaxOverflow == max )
+        assertTrue( shiftMinOverflow > min || shiftMinOverflow == min )
+    }
+
+    @Test
+    fun unsafeShift_with_coerced_max_size_values()
+    {
+        val maxShift = sizeOperations.maxValue
+        val maxOverflow = sizeOperations.unsafeAdd( maxShift, maxShift )
+        if ( maxShift == maxOverflow )
+        {
+            assertFailsWith<IllegalArgumentException> {
+                operations.unsafeShift( valueZero, maxShift, invertDirection = false )
+            }
+        }
+
+        val minShift = sizeOperations.minValue
+        val minOverflow = sizeOperations.unsafeSubtract( minShift, maxShift )
+        if ( minShift == minOverflow )
+        {
+            assertFailsWith<IllegalArgumentException> {
+                operations.unsafeShift(valueZero, minShift, invertDirection = true)
+            }
         }
     }
 }

--- a/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTypeOperationsTest.kt
+++ b/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTypeOperationsTest.kt
@@ -21,7 +21,7 @@ open class IntervalTypeOperationsTest<T : Comparable<T>, TSize : Comparable<TSiz
     fun minValue_can_be_converted_back_and_forth_using_TSize()
     {
         val min: T = operations.minValue
-        val minSize: TSize = operations.getDistanceTo( min )
+        val minSize: TSize = operations.getDistance( valueOperations.additiveIdentity, min )
         val minSizeValue: T = operations.unsafeValueAt( minSize )
         val subtractedMinSize: T = valueOperations.unsafeSubtract( valueOperations.additiveIdentity, minSizeValue )
         assertEquals( min, subtractedMinSize )
@@ -31,9 +31,36 @@ open class IntervalTypeOperationsTest<T : Comparable<T>, TSize : Comparable<TSiz
     fun maxValue_can_be_converted_back_and_forth_using_TSize()
     {
         val max: T = operations.maxValue
-        val maxSize: TSize = operations.getDistanceTo( max )
+        val maxSize: TSize = operations.getDistance( valueOperations.additiveIdentity, max )
         val maxSizeValue: T = operations.unsafeValueAt( maxSize )
         assertEquals( max, maxSizeValue )
+    }
+
+    @Test
+    fun getDistance_is_commutative()
+    {
+        val value = operations.unsafeValueAt( positiveSize )
+
+        val distance1 = operations.getDistance( valueOperations.additiveIdentity, value )
+        val distance2 = operations.getDistance( value, valueOperations.additiveIdentity )
+
+        assertEquals( positiveSize, distance1 )
+        assertEquals( positiveSize, distance2 )
+    }
+
+    @Test
+    fun getDistance_is_always_positive()
+    {
+        if ( !sizeOperations.isSignedType ) return
+
+        val negativeSize = sizeOperations.unsafeSubtract( sizeOperations.additiveIdentity, positiveSize )
+        val valueAtNegative = operations.unsafeValueAt( negativeSize )
+
+        val distance1 = operations.getDistance( valueOperations.additiveIdentity, valueAtNegative )
+        val distance2 = operations.getDistance( valueAtNegative, valueOperations.additiveIdentity )
+
+        assertEquals( positiveSize, distance1 )
+        assertEquals( positiveSize, distance2 )
     }
 
     @Test

--- a/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTypeOperationsTest.kt
+++ b/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTypeOperationsTest.kt
@@ -37,6 +37,19 @@ open class IntervalTypeOperationsTest<T : Comparable<T>, TSize : Comparable<TSiz
     }
 
     @Test
+    fun TSize_can_represent_full_range()
+    {
+        val rangeBelowZero = operations.getDistance( operations.minValue, valueZero )
+        val rangeAboveZero = operations.getDistance( valueZero, operations.maxValue )
+        val fullRange = operations.getDistance( operations.minValue, operations.maxValue )
+
+        assertEquals(
+            fullRange,
+            sizeOperations.unsafeAdd( rangeBelowZero, rangeAboveZero )
+        )
+    }
+
+    @Test
     fun getDistance_is_commutative()
     {
         val value = operations.unsafeValueAt( positiveSize )

--- a/kotlinx.interval/src/commonMain/kotlin/BasicTypeIntervals.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/BasicTypeIntervals.kt
@@ -13,11 +13,7 @@ class ByteInterval( start: Byte, isStartIncluded: Boolean, end: Byte, isEndInclu
     companion object
     {
         internal val Operations = createIntervalTypeOperations<Byte, UByte>(
-            getDistanceTo =
-            {
-                if ( it < 0 ) (0 - it).toUByte()
-                else it.toUByte()
-            },
+            getDistance = { a, b -> (b - a).absoluteValue.toUByte() },
             unsafeValueAt = { it.toByte() }
         )
     }
@@ -41,11 +37,7 @@ class ShortInterval( start: Short, isStartIncluded: Boolean, end: Short, isEndIn
     companion object
     {
         internal val Operations = createIntervalTypeOperations<Short, UShort>(
-            getDistanceTo =
-            {
-                if ( it < 0 ) (0 - it).toUShort()
-                else it.toUShort()
-            },
+            getDistance = { a, b -> (b - a).absoluteValue.toUShort() },
             unsafeValueAt = { it.toShort() }
         )
     }
@@ -69,10 +61,9 @@ class IntInterval( start: Int, isStartIncluded: Boolean, end: Int, isEndIncluded
     companion object
     {
         internal val Operations = createIntervalTypeOperations<Int, UInt>(
-            getDistanceTo =
-            {
-                if ( it < 0 ) (0 - it).toUInt()
-                else it.toUInt()
+            getDistance = { a, b ->
+                if ( a < 0 != b < 0 ) a.absoluteValue.toUInt() + b.absoluteValue.toUInt()
+                else (b - a).absoluteValue.toUInt()
             },
             unsafeValueAt = { it.toInt() }
         )
@@ -97,10 +88,9 @@ class LongInterval( start: Long, isStartIncluded: Boolean, end: Long, isEndInclu
     companion object
     {
         internal val Operations = createIntervalTypeOperations<Long, ULong>(
-            getDistanceTo =
-            {
-                if ( it < 0 ) (0 - it).toULong()
-                else it.toULong()
+            getDistance = { a, b ->
+                if ( a < 0 != b < 0 ) a.absoluteValue.toULong() + b.absoluteValue.toULong()
+                else (b - a).absoluteValue.toULong()
             },
             unsafeValueAt = { it.toLong() }
         )
@@ -125,7 +115,7 @@ class FloatInterval( start: Float, isStartIncluded: Boolean, end: Float, isEndIn
     companion object
     {
         internal val Operations = createIntervalTypeOperations<Float, Double>(
-            getDistanceTo = { it.absoluteValue.toDouble() },
+            getDistance = { a, b -> (b.toDouble() - a.toDouble()).absoluteValue },
             unsafeValueAt = { it.absoluteValue.toFloat() }
         )
     }
@@ -151,7 +141,7 @@ class DoubleInterval( start: Double, isStartIncluded: Boolean, end: Double, isEn
     companion object
     {
         internal val Operations = createIntervalTypeOperations<Double, Double>(
-            getDistanceTo = { it.absoluteValue },
+            getDistance = { a, b -> (b - a).absoluteValue },
             unsafeValueAt = { it.absoluteValue }
         )
     }
@@ -175,7 +165,10 @@ class UByteInterval( start: UByte, isStartIncluded: Boolean, end: UByte, isEndIn
     companion object
     {
         internal val Operations = createIntervalTypeOperations<UByte, UByte>(
-            getDistanceTo = { it },
+            getDistance = { a, b ->
+                if ( a < b ) (b - a).toUByte()
+                else (a - b).toUByte()
+            },
             unsafeValueAt = { it },
         )
     }
@@ -199,7 +192,10 @@ class UShortInterval( start: UShort, isStartIncluded: Boolean, end: UShort, isEn
     companion object
     {
         internal val Operations = createIntervalTypeOperations<UShort, UShort>(
-            getDistanceTo = { it },
+            getDistance = { a, b ->
+                if ( a < b ) (b - a).toUShort()
+                else (a - b).toUShort()
+            },
             unsafeValueAt = { it }
         )
     }
@@ -223,7 +219,7 @@ class UIntInterval( start: UInt, isStartIncluded: Boolean, end: UInt, isEndInclu
     companion object
     {
         internal val Operations = createIntervalTypeOperations<UInt, UInt>(
-            getDistanceTo = { it },
+            getDistance = { a, b -> if ( a < b ) b - a else a - b },
             unsafeValueAt = { it }
         )
     }
@@ -247,7 +243,7 @@ class ULongInterval( start: ULong, isStartIncluded: Boolean, end: ULong, isEndIn
     companion object
     {
         internal val Operations = createIntervalTypeOperations<ULong, ULong>(
-            getDistanceTo = { it },
+            getDistance = { a, b -> if ( a < b ) b - a else a - b },
             unsafeValueAt = { it }
         )
     }
@@ -271,7 +267,7 @@ class CharInterval( start: Char, isStartIncluded: Boolean, end: Char, isEndInclu
     companion object
     {
         internal val Operations = createIntervalTypeOperations<Char, UShort>(
-            getDistanceTo = { it.code.toUShort() },
+            getDistance = { a, b -> (b - a).absoluteValue.toUShort() },
             unsafeValueAt = { Char( it ) }
         )
     }

--- a/kotlinx.interval/src/commonMain/kotlin/BasicTypeIntervals.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/BasicTypeIntervals.kt
@@ -114,10 +114,17 @@ class FloatInterval( start: Float, isStartIncluded: Boolean, end: Float, isEndIn
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<Float, Double>(
+        internal val Operations = object : IntervalTypeOperations<Float, Double>(
+            FloatOperations,
+            DoubleOperations,
             getDistance = { a, b -> (b.toDouble() - a.toDouble()).absoluteValue },
             unsafeValueAt = { it.absoluteValue.toFloat() }
         )
+        {
+            private val MAX = Float.MAX_VALUE / 2
+            override val minValue: Float = -MAX
+            override val maxValue: Float = MAX
+        }
     }
 }
 
@@ -132,18 +139,23 @@ fun interval( start: Float, end: Float, isStartIncluded: Boolean = true, isEndIn
 /**
  * An [Interval] representing the set of all [Double] values lying between a provided [start] and [end] value.
  * The interval can be closed, open, or half-open, as determined by [isStartIncluded] and [isEndIncluded].
- *
- * The [size] of [Double] intervals which exceed [Double.MAX_VALUE] will be [Double.POSITIVE_INFINITY].
  */
 class DoubleInterval( start: Double, isStartIncluded: Boolean, end: Double, isEndIncluded: Boolean )
     : Interval<Double, Double>( start, isStartIncluded, end, isEndIncluded, Operations )
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<Double, Double>(
+        internal val Operations = object : IntervalTypeOperations<Double, Double>(
+            DoubleOperations,
+            DoubleOperations,
             getDistance = { a, b -> (b - a).absoluteValue },
             unsafeValueAt = { it.absoluteValue }
         )
+        {
+            private val MAX = Double.MAX_VALUE / 2
+            override val minValue: Double = -MAX
+            override val maxValue: Double = MAX
+        }
     }
 }
 

--- a/kotlinx.interval/src/commonMain/kotlin/BasicTypeOperations.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/BasicTypeOperations.kt
@@ -83,8 +83,8 @@ internal object LongOperations : TypeOperations<Long>
 internal object FloatOperations : TypeOperations<Float>
 {
     override val additiveIdentity: Float = 0f
-    override val minValue: Float = -Float.MAX_VALUE
-    override val maxValue: Float = Float.MAX_VALUE
+    override val minValue: Float = Float.NEGATIVE_INFINITY
+    override val maxValue: Float = Float.POSITIVE_INFINITY
     override val spacing: Float? = null
 
     override fun unsafeAdd( a: Float, b: Float ): Float = a + b
@@ -94,8 +94,8 @@ internal object FloatOperations : TypeOperations<Float>
 internal object DoubleOperations : TypeOperations<Double>
 {
     override val additiveIdentity: Double = 0.0
-    override val minValue: Double = -Double.MAX_VALUE
-    override val maxValue: Double = Double.MAX_VALUE
+    override val minValue: Double = Double.NEGATIVE_INFINITY
+    override val maxValue: Double = Double.POSITIVE_INFINITY
     override val spacing: Double? = null
 
     override fun unsafeAdd( a: Double, b: Double ): Double = a + b

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -77,23 +77,7 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
     /**
      * The absolute difference between [start] and [end].
      */
-    val size: TSize get()
-    {
-        val zero = valueOperations.additiveIdentity
-        val startDistance = operations.getDistanceTo( start )
-        val endDistance = operations.getDistanceTo( end )
-        val valuesHaveOppositeSign = start <= zero != end <= zero
-
-        return if ( valuesHaveOppositeSign )
-        {
-            sizeOperations.unsafeAdd( startDistance, endDistance )
-        }
-        else
-        {
-            if ( startDistance < endDistance ) sizeOperations.unsafeSubtract( endDistance, startDistance )
-            else sizeOperations.unsafeSubtract( startDistance, endDistance )
-        }
-    }
+    val size: TSize get() = operations.getDistance( start, end )
 
 
     override fun iterator(): Iterator<Interval<T, TSize>> = listOf( this ).iterator()

--- a/kotlinx.interval/src/commonMain/kotlin/IntervalTypeOperations.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/IntervalTypeOperations.kt
@@ -15,9 +15,9 @@ abstract class IntervalTypeOperations<T : Comparable<T>, TSize : Comparable<TSiz
      */
     val sizeOperations: TypeOperations<TSize>,
     /**
-     * Return the distance from a specified value [T] to the additive identity (usually "zero") of [T].
+     * Return the distance between two values of [T].
      */
-    val getDistanceTo: (T) -> TSize,
+    val getDistance: (T, T) -> TSize,
     /**
      * Returns the positive value [T] at the specified distance from the additive identity (usually "zero") of [T].
      * This isn't safeguarded against overflows in case the value is larger than the maximum value of [T].
@@ -55,15 +55,15 @@ inline fun <reified T : Comparable<T>, reified TSize : Comparable<TSize>> create
      */
     sizeOperations: TypeOperations<TSize> = getBasicTypeOperationsFor(),
     /**
-     * A function returning the distance from a specified value [T] to the additive identity (usually "zero") of [T].
+     * A function returning the distance between values of [T].
      */
-    noinline getDistanceTo: (T) -> TSize,
+    noinline getDistance: (T, T) -> TSize,
     /**
      * A function returning the value [T] at the specified distance from the additive identity (usually "zero") of [T],
      * not safeguarded against overflows in case the value is larger than the maximum value of [T].
      */
     noinline unsafeValueAt: (TSize) -> T
-) = object : IntervalTypeOperations<T, TSize>( valueOperations, sizeOperations, getDistanceTo, unsafeValueAt )
+) = object : IntervalTypeOperations<T, TSize>( valueOperations, sizeOperations, getDistance, unsafeValueAt )
 {
     override val minValue: T = valueOperations.minValue
     override val maxValue: T = valueOperations.maxValue


### PR DESCRIPTION
Moving an interval can overflow in case the new values of the interval can't be represented by the type.

In the majority of use cases this can probably be ignored, but in those cases where an overflow _does_ occur, an assumption was made that the most likely desirable behavior is to move the interval _as far as possible_. I.e., 'clamp' the operation to the possible value range.

But, to ensure the caller can still tell overflowed operations apart from fully successful shift operations, the _actual_ amount by which the interval is shifted is included in the return value.

In addition: while writing unit tests for `shift`, I noticed some errors on `EmptyIntervalUnion` operations, which are now fixed.

Some things left to consider:
- [x] Add a test to verify the assumption that "all negative values of TSize have a positive counterpart". And, is this a fair limitation for potential types of `TSize`? **Found a workaround/no longer a requirement.**
- [x] Deal with precision issues at large values. This can probably lead to intervals "collapsing" to single values, and failing on initialization with two exclusive bounds. If dealt with, maybe increase possible range of float and double again to allow loss of precision. **Postponed: #64 **
- [x] Improve shift overflow tests so they are less sensitive to precision issues. Maybe add extra test input if relevant?
- [x] Add test + fix to prevent `unsafeShift` infinite loops on "infinity" values.
- [x] Should the _actual_ resulting shifted value in case of overflows be signed? Is it currently consistent? **Should be signed now, but maybe needs more tests.**
- [x] Shift union pairs (TODO item)