### PR TITLE
Fix: prevent size overflows

### DIFF
--- a/kotlinx.interval.datetime/src/commonMain/kotlin/DateTimeTypeOperations.kt
+++ b/kotlinx.interval.datetime/src/commonMain/kotlin/DateTimeTypeOperations.kt
@@ -29,7 +29,7 @@ internal object DurationOperations : TypeOperations<Duration>
 {
     override val additiveIdentity: Duration = Duration.ZERO
 
-    private const val MAX_MILLIS = Long.MAX_VALUE / 2
+    internal const val MAX_MILLIS = Long.MAX_VALUE / 2
     override val minValue: Duration = -MAX_MILLIS.milliseconds
     override val maxValue: Duration = MAX_MILLIS.milliseconds
     override val spacing: Duration? = null

--- a/kotlinx.interval.datetime/src/commonMain/kotlin/InstantInterval.kt
+++ b/kotlinx.interval.datetime/src/commonMain/kotlin/InstantInterval.kt
@@ -3,6 +3,7 @@ package io.github.whathecode.kotlinx.interval.datetime
 import io.github.whathecode.kotlinx.interval.Interval
 import io.github.whathecode.kotlinx.interval.IntervalTypeOperations
 import kotlinx.datetime.Instant
+import kotlin.math.absoluteValue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
@@ -17,8 +18,26 @@ class InstantInterval( start: Instant, isStartIncluded: Boolean, end: Instant, i
 {
     companion object
     {
-        internal val Operations = IntervalTypeOperations( InstantOperations, DurationOperations )
-            { time: Instant -> (time.epochSeconds.seconds + time.nanosecondsOfSecond.nanoseconds).absoluteValue }
+        internal val Operations = object : IntervalTypeOperations<Instant, Duration>(
+            InstantOperations,
+            DurationOperations,
+            getDistanceTo = { (InstantOperations.additiveIdentity - it).absoluteValue },
+            unsafeValueAt = { InstantOperations.additiveIdentity + it }
+        )
+        {
+            // Maximum positive/negative value to ensure the interval size can be represented by Duration.
+            // One is subtracted to exclude `Duration.Infinity`.
+            private val MAX = (DurationOperations.MAX_MILLIS - 1) / 2
+
+            // Some platforms have a smaller range than `MAX` duration, and values are clamped on initialization.
+            private val COERCED_MAX_SECONDS = minOf(
+                Instant.fromEpochMilliseconds( -MAX ).epochSeconds.absoluteValue,
+                Instant.fromEpochMilliseconds( MAX ).epochSeconds.absoluteValue
+            )
+
+            override val minValue: Instant = Instant.fromEpochSeconds( -COERCED_MAX_SECONDS, 0 )
+            override val maxValue: Instant = Instant.fromEpochSeconds( COERCED_MAX_SECONDS, 0 )
+        }
     }
 }
 

--- a/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTest.kt
+++ b/kotlinx.interval.testcases/src/commonMain/kotlin/IntervalTest.kt
@@ -66,6 +66,23 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
     }
 
     @Test
+    fun has_valid_type_operations()
+    {
+        // Minimum allowed value of T can be converted back and forth using TSize.
+        val min: T = operations.minValue
+        val minSize: TSize = operations.getDistanceTo( min )
+        val minSizeValue: T = operations.unsafeValueAt( minSize )
+        val subtractedMinSize: T = valueOperations.unsafeSubtract( valueOperations.additiveIdentity, minSizeValue )
+        assertEquals( min, subtractedMinSize )
+
+        // Maximum allowed value of T can be converted back and forth using TSize.
+        val max: T = operations.maxValue
+        val maxSize: TSize = operations.getDistanceTo( max )
+        val maxSizeValue: T = operations.unsafeValueAt( maxSize )
+        assertEquals( max, maxSizeValue )
+    }
+
+    @Test
     fun constructing_open_or_half_open_intervals_with_same_start_and_end_fails()
     {
         assertFailsWith<IllegalArgumentException> { createOpenInterval( a, a ) }
@@ -147,10 +164,10 @@ abstract class IntervalTest<T : Comparable<T>, TSize : Comparable<TSize>>(
     @Test
     fun size_can_be_greater_than_max_value()
     {
-        val fullRange = createClosedInterval( valueOperations.minValue, valueOperations.maxValue ).size
+        val fullRange = createClosedInterval( operations.minValue, operations.maxValue ).size
         val identity = valueOperations.additiveIdentity
-        val rangeBelowIdentity = createClosedInterval( valueOperations.minValue, identity ).size
-        val rangeAboveIdentity = createClosedInterval( identity, valueOperations.maxValue ).size
+        val rangeBelowIdentity = createClosedInterval( operations.minValue, identity ).size
+        val rangeAboveIdentity = createClosedInterval( identity, operations.maxValue ).size
 
         assertEquals(
             fullRange,

--- a/kotlinx.interval/src/commonMain/kotlin/BasicTypeIntervals.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/BasicTypeIntervals.kt
@@ -12,11 +12,14 @@ class ByteInterval( start: Byte, isStartIncluded: Boolean, end: Byte, isEndInclu
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<Byte, UByte>()
+        internal val Operations = createIntervalTypeOperations<Byte, UByte>(
+            getDistanceTo =
             {
                 if ( it < 0 ) (0 - it).toUByte()
                 else it.toUByte()
-            }
+            },
+            unsafeValueAt = { it.toByte() }
+        )
     }
 }
 
@@ -37,11 +40,14 @@ class ShortInterval( start: Short, isStartIncluded: Boolean, end: Short, isEndIn
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<Short, UShort>()
+        internal val Operations = createIntervalTypeOperations<Short, UShort>(
+            getDistanceTo =
             {
                 if ( it < 0 ) (0 - it).toUShort()
                 else it.toUShort()
-            }
+            },
+            unsafeValueAt = { it.toShort() }
+        )
     }
 }
 
@@ -62,11 +68,14 @@ class IntInterval( start: Int, isStartIncluded: Boolean, end: Int, isEndIncluded
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<Int, UInt>()
+        internal val Operations = createIntervalTypeOperations<Int, UInt>(
+            getDistanceTo =
             {
                 if ( it < 0 ) (0 - it).toUInt()
                 else it.toUInt()
-            }
+            },
+            unsafeValueAt = { it.toInt() }
+        )
     }
 }
 
@@ -87,11 +96,14 @@ class LongInterval( start: Long, isStartIncluded: Boolean, end: Long, isEndInclu
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<Long, ULong>()
+        internal val Operations = createIntervalTypeOperations<Long, ULong>(
+            getDistanceTo =
             {
                 if ( it < 0 ) (0 - it).toULong()
                 else it.toULong()
-            }
+            },
+            unsafeValueAt = { it.toLong() }
+        )
     }
 }
 
@@ -112,7 +124,10 @@ class FloatInterval( start: Float, isStartIncluded: Boolean, end: Float, isEndIn
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<Float, Double> { it.absoluteValue.toDouble() }
+        internal val Operations = createIntervalTypeOperations<Float, Double>(
+            getDistanceTo = { it.absoluteValue.toDouble() },
+            unsafeValueAt = { it.toFloat() }
+        )
     }
 }
 
@@ -135,7 +150,10 @@ class DoubleInterval( start: Double, isStartIncluded: Boolean, end: Double, isEn
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<Double, Double> { it.absoluteValue }
+        internal val Operations = createIntervalTypeOperations<Double, Double>(
+            getDistanceTo = { it.absoluteValue },
+            unsafeValueAt = { it }
+        )
     }
 }
 
@@ -156,7 +174,10 @@ class UByteInterval( start: UByte, isStartIncluded: Boolean, end: UByte, isEndIn
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<UByte, UByte> { it }
+        internal val Operations = createIntervalTypeOperations<UByte, UByte>(
+            getDistanceTo = { it },
+            unsafeValueAt = { it },
+        )
     }
 }
 
@@ -177,7 +198,10 @@ class UShortInterval( start: UShort, isStartIncluded: Boolean, end: UShort, isEn
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<UShort, UShort> { it }
+        internal val Operations = createIntervalTypeOperations<UShort, UShort>(
+            getDistanceTo = { it },
+            unsafeValueAt = { it }
+        )
     }
 }
 
@@ -198,7 +222,10 @@ class UIntInterval( start: UInt, isStartIncluded: Boolean, end: UInt, isEndInclu
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<UInt, UInt> { it }
+        internal val Operations = createIntervalTypeOperations<UInt, UInt>(
+            getDistanceTo = { it },
+            unsafeValueAt = { it }
+        )
     }
 }
 
@@ -219,7 +246,10 @@ class ULongInterval( start: ULong, isStartIncluded: Boolean, end: ULong, isEndIn
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<ULong, ULong> { it }
+        internal val Operations = createIntervalTypeOperations<ULong, ULong>(
+            getDistanceTo = { it },
+            unsafeValueAt = { it }
+        )
     }
 }
 
@@ -240,7 +270,10 @@ class CharInterval( start: Char, isStartIncluded: Boolean, end: Char, isEndInclu
 {
     companion object
     {
-        internal val Operations = createIntervalTypeOperations<Char, UShort> { it.code.toUShort() }
+        internal val Operations = createIntervalTypeOperations<Char, UShort>(
+            getDistanceTo = { it.code.toUShort() },
+            unsafeValueAt = { Char( it ) }
+        )
     }
 }
 

--- a/kotlinx.interval/src/commonMain/kotlin/Interval.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/Interval.kt
@@ -22,6 +22,11 @@ open class Interval<T : Comparable<T>, TSize : Comparable<TSize>>(
 {
     init
     {
+        require( lowerBound >= operations.minValue )
+            { "Lower bound shouldn't be smaller than ${operations.minValue} to prevent interval size overflows." }
+        require( upperBound <= operations.maxValue )
+            { "Upper bound shouldn't be greater than ${operations.maxValue} to prevent interval size overflows." }
+
         if ( !isStartIncluded || !isEndIncluded )
         {
             require( start != end ) { "Open or half-open intervals should have differing start and end value." }

--- a/kotlinx.interval/src/commonMain/kotlin/IntervalTypeOperations.kt
+++ b/kotlinx.interval/src/commonMain/kotlin/IntervalTypeOperations.kt
@@ -3,9 +3,9 @@ package io.github.whathecode.kotlinx.interval
 
 /**
  * Provides generic access to the predefined set of type operators of interval values of type [T] ([valueOperations])
- * and distances between values of type [TSize] ([sizeOperations]).
+ * and distances between values of type [TSize] ([sizeOperations]), and operations to convert between them.
  */
-class IntervalTypeOperations<T : Comparable<T>, TSize : Comparable<TSize>>(
+abstract class IntervalTypeOperations<T : Comparable<T>, TSize : Comparable<TSize>>(
     /**
      * Provide access to the predefined set of operators of [T].
      */
@@ -17,8 +17,24 @@ class IntervalTypeOperations<T : Comparable<T>, TSize : Comparable<TSize>>(
     /**
      * Return the distance from a specified value [T] to the additive identity (usually "zero") of [T].
      */
-    val getDistanceTo: (T) -> TSize
+    val getDistanceTo: (T) -> TSize,
+    /**
+     * Returns the value [T] at the specified distance from the additive identity (usually "zero") of [T].
+     * This isn't safeguarded against overflows in case the value is larger than the maximum value of [T].
+     */
+    val unsafeValueAt: (TSize) -> T
 )
+{
+    /**
+     * The minimum allowed value of [T] to ensure that the interval size can still be represented by [TSize].
+     */
+    abstract val minValue: T
+
+    /**
+     * The maximum allowed value of [T] to ensure that the interval size can still be represented by [TSize].
+     */
+    abstract val maxValue: T
+}
 
 
 /**
@@ -41,5 +57,14 @@ inline fun <reified T : Comparable<T>, reified TSize : Comparable<TSize>> create
     /**
      * A function returning the distance from a specified value [T] to the additive identity (usually "zero") of [T].
      */
-    noinline getDistanceTo: (T) -> TSize
-) = IntervalTypeOperations( valueOperations, sizeOperations, getDistanceTo )
+    noinline getDistanceTo: (T) -> TSize,
+    /**
+     * A function returning the value [T] at the specified distance from the additive identity (usually "zero") of [T],
+     * not safeguarded against overflows in case the value is larger than the maximum value of [T].
+     */
+    noinline unsafeValueAt: (TSize) -> T
+) = object : IntervalTypeOperations<T, TSize>( valueOperations, sizeOperations, getDistanceTo, unsafeValueAt )
+{
+    override val minValue: T = valueOperations.minValue
+    override val maxValue: T = valueOperations.maxValue
+}


### PR DESCRIPTION
`InstantInterval.size` could overflow and return `Infinity`. To fix this, coerce values into a range which always allows a valid `size` to be returned.

`IntervalTypeOperations.unsafeValueAt` is added to test this, and because it will be needed to implement future interval operations.