### PR TITLE
Remove `iosArm64` target

### DIFF
--- a/build-logic/src/main/kotlin/interval.library-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/interval.library-conventions.gradle.kts
@@ -40,7 +40,6 @@ kotlin {
     macosArm64()
     iosSimulatorArm64()
     iosX64()
-    iosArm64()
 
     mingwX64()
 


### PR DESCRIPTION
Publishing snapshots is failing on this target. Remove for now to see whether this is the sole problem.