### PR TITLE
Build: migrate to Sonatype Central

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,8 +32,8 @@ if (properties.containsKey("snapshot"))
 nexusPublishing {
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(publishProperties["repository.username"] as? String)
             password.set(publishProperties["repository.password"] as? String)
         }


### PR DESCRIPTION
OSSRH has been deprecated since June 30 2025: https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-ossrh